### PR TITLE
Fix evm address conversion utility

### DIFF
--- a/src/utils/evmToSubstrate.utils.ts
+++ b/src/utils/evmToSubstrate.utils.ts
@@ -1,10 +1,15 @@
-import { hexToU8a, u8aToU8a } from '@polkadot/util';
-import { encodeAddress } from '@polkadot/util-crypto';
+import assert from 'assert'
+import { hexToU8a } from '@polkadot/util'
+import { encodeAddress } from '@polkadot/util-crypto'
 
 /// Convert the EVM address to Substrate address
 /// Default ss58Prefix is 0
-export function evmToSubstrate(address: string, ss58Prefix=0): string {
-    let u8a = hexToU8a(address);
-    return encodeAddress(u8a,ss58Prefix);
+export function evmToSubstrate(address: string, ss58Prefix = 0): string {
+    if (address.startsWith('0x')) {
+        address = address.slice(2)
+    }
+    assert(address.length === 40, 'Invalid EVM address')
+    const u8a = hexToU8a(address)
+    return encodeAddress(u8a, ss58Prefix)
 }
     


### PR DESCRIPTION
## Summary
- validate `evmToSubstrate` input and strip leading `0x`

## Testing
- `npm run build` *(fails: Cannot find type definition file for ...)*

------
https://chatgpt.com/codex/tasks/task_e_68859b208294832cb0b894dfefd71541